### PR TITLE
fix(availability): ensure slot time format is always HH:mm:ss

### DIFF
--- a/frontend/src/pages/ProfileEvaluator.vue
+++ b/frontend/src/pages/ProfileEvaluator.vue
@@ -165,6 +165,11 @@ const evaluator = createResource({
 	onSuccess(data) {
 		if (data.slots.unavailable_from) from.value = data.slots.unavailable_from
 		if (data.slots.unavailable_to) to.value = data.slots.unavailable_to
+
+		data.slots.schedule.forEach((slot) => {
+			slot.start_time = formatTime(slot.start_time)
+			slot.end_time = formatTime(slot.end_time)
+		})
 	},
 })
 
@@ -320,5 +325,13 @@ const days = computed(() => {
 		},
 	]
 })
+
+const formatTime = (time) => {
+	if (!time) return ''
+	const parts = time.split(':')
+	if (parts.length < 3) return time
+	const hours = parts[0].padStart(2, '0')
+	return `${hours}:${parts[1]}:${parts[2]}`
+}
 
 </script>


### PR DESCRIPTION

This PR fixes an issue where start_time values without a leading zero (e.g., 9:00:00 instead of 09:00:00) were not displaying correctly in the My Availability section. A formatTime function was added to ensure consistent HH:mm:ss formatting before binding values to the FormControl. This fix ensures proper display and editing of availability slots without requiring backend changes. Tested by verifying slot display, creation, and updates.